### PR TITLE
Allow Globalhashes

### DIFF
--- a/Expedition.py
+++ b/Expedition.py
@@ -67,12 +67,24 @@ class Expedition:
     self.page = pywikibot.Page(site, self.pageName)
     pageNameParts = re.split("[ _]+", self.pageName)
     self.date = pageNameParts[0]
-    self.lat = pageNameParts[1]
-    self.lon = pageNameParts[2]
-    self.gratAdd = self.lat+" "+self.lon
+    graticule = pageNameParts[1:3] # either ["global"] or ["lat", "lon"]
+    self.gratAdd = u" ".join(graticule)
+    self.gratAddr = u",".join(graticule)
+    isGlobalhash = pageNameParts[1] == "global"
+    
+    if isGlobalhash:
+      self.lat = None
+      self.lon = None
+    else:
+      self.lat = pageNameParts[1]
+      self.lon = pageNameParts[2]
+    
     name_list = db.getLatLon(self.lat,self.lon)
     if((name_list == None) or (name_list[1] == None) or (name_list[2] == None)):
-      self.gratName = u"Unknown (" + self.lat + u", " + self.lon + u")"
+      if isGlobalhash:
+        self.gratName = u"Globalhash"
+      else:
+        self.gratName = u"Unknown (" + self.lat + u", " + self.lon + u")"
     else:
       self.gratName = name_list[1] + u", " + name_list[2]
     if self.page.isRedirectPage():
@@ -222,7 +234,7 @@ class Expedition:
 
   def subFormat(self, format = None, user = None, oldText = None, grat = None):
     if grat:
-        grat_addr = self.lat + "," + self.lon
+        grat_addr = self.gratAddr
         if grat_addr != grat:
             return None
     userFound = False
@@ -279,4 +291,3 @@ class Expedition:
       formatted_out = rex.sub(sub, formatted_out)
     self.people_temp = None
     return formatted_out
-

--- a/ExpeditionSummaries.py
+++ b/ExpeditionSummaries.py
@@ -18,7 +18,7 @@ class ExpeditionSummaries:
   def _putExpeditionSummaries(self, db):
     allSummaries = []
     for page in self.pageList:
-      if(re.match("\d{4}-\d{2}-\d{2} [-0-9]{1,4} [-0-9]{1,4}$", page.title())):
+      if(re.match("\d{4}-\d{2}-\d{2} ([-0-9]{1,4} [-0-9]{1,4}|global)$", page.title())):
         pywikibot.output("Parsing page " + str(self.pageList.index(page)) + " of " + str(len(self.pageList)) + " : " + page.title())
         exped = Expedition.Expedition(page.site, page.title(), db)
         self.expedList.append(exped)

--- a/aperfectbot.py
+++ b/aperfectbot.py
@@ -158,7 +158,7 @@ def getExpeditionSummaries(expPages, db, dates, firstDate):
         for date in dates:
             allSummaries[date] = []
     for page in expPages:
-        if(re.match("\d{4}-\d{2}-\d{2} [-0-9]{1,4} [-0-9]{1,4}$", page.title())):
+        if(re.match("\d{4}-\d{2}-\d{2} ([-0-9]{1,4} [-0-9]{1,4}|global)$", page.title())):
             pageNameParts = re.split("[ _]+", page.title())
             if (firstDate == None) or (pageNameParts[0] >= firstDate):
                 pywikibot.output("Parsing page : " + page.title())


### PR DESCRIPTION
Currently, AperfectBot does not recognize Globalhashes. They are not represented in the list of expeditions per day or per user.

Merging this pull request will change that.

The code has been tested and works, see:

- https://geohashing.site/?diff=805767
- https://geohashing.site/?diff=805768