### PR TITLE
Display Drag-Alongs in their correct case

### DIFF
--- a/UserListGenerator.py
+++ b/UserListGenerator.py
@@ -161,6 +161,8 @@ def identifyParticipants(origtext, page, getLinks = False, getSections = True):
           else:
             fuzzy[partls]=fuzzy.get(partls,0) + score
             usernames[partls] = part.strip()
+            if partls not in userlinks:
+              userlinks[partls] = part.strip()
   
   #increase the score of a potential participant by the number of mentions vs total mentions 
   mentions = {}


### PR DESCRIPTION
Currently, AperfectBot always displays Drag-Alongs in lowercase.

Merging this pull request will change that. Drag-Alongs will be displayed in the case in which they were entered on the expedition page.

The code has been tested and works, see: https://geohashing.site/index.php?diff=805814